### PR TITLE
Update the receive email hook to accept email from anonymous watchers

### DIFF
--- a/lib/redmine_anonymous_watchers/mail_handler_patch.rb
+++ b/lib/redmine_anonymous_watchers/mail_handler_patch.rb
@@ -32,11 +32,12 @@ module RedmineAnonymousWatchers
           end
         end
 
-        self.receive_without_anonymous(email, options=options)
+        return_value = self.receive_without_anonymous(email, options=options)
 
         if deactivate_user
           user.lock!
         end
+        return return_value
       end
 
       def add_watchers_with_anonymous(obj)

--- a/lib/redmine_anonymous_watchers/mail_handler_patch.rb
+++ b/lib/redmine_anonymous_watchers/mail_handler_patch.rb
@@ -7,10 +7,38 @@ module RedmineAnonymousWatchers
       base.class_eval do
         alias_method :add_watchers_without_anonymous, :add_watchers
         alias_method :add_watchers, :add_watchers_with_anonymous
+
+        alias_method :receive_without_anonymous, :receive
+        alias_method :receive, :receive_with_anonymous
       end
     end
 
     module InstanceMethods
+      def receive_with_anonymous(email, options={})
+        # The only check we do here is whether it's an anonymous watcher, and
+        # if so we temporarily activate the user for the duration of the recieve
+        # code.
+        #
+        # We have to use the mutating! versions that update the database since
+        # the original receive code will fetch it again.
+
+        deactivate_user = false
+        sender_email = email.from.to_a.first.to_s.strip
+        user = User.find_by_mail(sender_email) if sender_email.present?
+        if user && !user.active?
+          if user.groups.any? { |group| group.name == 'Anonymous Watchers' }
+            user.activate!
+            deactivate_user = true
+          end
+        end
+
+        self.receive_without_anonymous(email, options=options)
+
+        if deactivate_user
+          user.lock!
+        end
+      end
+
       def add_watchers_with_anonymous(obj)
         add_watchers_without_anonymous(obj)
         if handler_options[:no_permission_check] || user.allowed_to?("add_#{obj.class.name.underscore}_watchers".to_sym, obj.project)


### PR DESCRIPTION
Since the watchers are locked (and we want to keep them that way) the
original redmine code rejected them as senders. This patch will make
sure they are temporarily activated for the duration of the receive
code.

It would probably be better if the name of the "Anonymous Watchers"
group was a constant in the code somewhere, not sure how to do that,
but this seems to work for the moment.