### PR TITLE
Make it possible to add existing anonymous wathcers

### DIFF
--- a/lib/redmine_anonymous_watchers/watchers_controller_patch.rb
+++ b/lib/redmine_anonymous_watchers/watchers_controller_patch.rb
@@ -76,12 +76,19 @@ module RedmineAnonymousWatchers
           mails = watcher[:mails].split(/[\s,]+/) || [watcher[:mail]]
           user_ids = []
           mails.each do |mail|
-            if(u = User.find_by_mail(mail))
-              user_ids << u.id
-            else
+            add_anonymous = false
+
+            u = User.find_by_mail(mail)
+            if !u || (u.is_a?(User) && u.groups.any? { |group| group.name == 'Anonymous Watchers' })
+              add_anonymous = true
+            end
+
+            if add_anonymous
               @watchables.each do |watchable|
                 AnonymousWatcher.create(:watchable => watchable, :mail => mail) if mail.present?
                end
+            else
+              user_ids << u.id
             end
           end
         end

--- a/lib/redmine_anonymous_watchers/watchers_controller_patch.rb
+++ b/lib/redmine_anonymous_watchers/watchers_controller_patch.rb
@@ -76,17 +76,11 @@ module RedmineAnonymousWatchers
           mails = watcher[:mails].split(/[\s,]+/) || [watcher[:mail]]
           user_ids = []
           mails.each do |mail|
-            add_anonymous = false
-
             u = User.find_by_mail(mail)
             if !u || (u.is_a?(User) && u.groups.any? { |group| group.name == 'Anonymous Watchers' })
-              add_anonymous = true
-            end
-
-            if add_anonymous
               @watchables.each do |watchable|
                 AnonymousWatcher.create(:watchable => watchable, :mail => mail) if mail.present?
-               end
+              end
             else
               user_ids << u.id
             end


### PR DESCRIPTION
We create a new user for each anonymous wathcers (once emails are sent).
This caused the previous code to try to add inactive low privilige
accounts to the list of anonymous wathcers instead of just adding
another row to the anonymous_watchers table. That didn't work since that
user didn't have permission to watch in the project.

This patch makes sure that only users that are not anonymous wathcers
are added as normal wathcers and that anonymous wathcers gets added by
email.